### PR TITLE
remove noalpha support, more script fixes

### DIFF
--- a/flare/repack.cmd
+++ b/flare/repack.cmd
@@ -31,7 +31,7 @@ exit /b 0
 FOR /R %game_dir%\mods\%1\animations\enemies %%A IN (*.txt) DO (
 	call :pack %1 %%A
 	pushd %game_dir%
-	git commit -a -m "repack spritesheets"
+	git commit -a -m "repack %%~nA.png"
 	popd
 )
 GOTO :eof


### PR DESCRIPTION
Two things remain:
1. scripts should get image path from animation file(png and txt names do not always match)
2. This will automatically fix issue n2: windows script is unable to extract png path from animation path
